### PR TITLE
Check if instance data is correct before parsing

### DIFF
--- a/src/auth.js
+++ b/src/auth.js
@@ -13,7 +13,14 @@ module.exports = function Auth({setOauth}) {
 		let thisUrl = new URL(window.location.origin);
 		thisUrl.pathname = "/api/v1/instance";
 		fetch(thisUrl.href)
-			.then((res) => res.json())
+			.then((res) => {
+				if (res.status && res.status === 200) {
+					let ct = res.headers.get("content-type");
+					if (ct && ct.indexOf("application/json") !== -1) {
+						return res.json();
+					}
+				}
+			})
 			.then((json) => {
 				if (json && json.uri) {
 					if (isStillMounted) {


### PR DESCRIPTION
Fixes #10 by checking the response type of the supposed JSON. The reason it fails usually, because the response type doesn't contain JSON (e.g. when running on another domain).